### PR TITLE
Add script for generating bloom filter on backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third-party/catch2"]
 	path = third-party/catch2
-	url = https://github.com/catchorg/Catch2.git
+	url = https://github.com/duckduckgo/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(ddg_bloom_cpp)
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_COMPILER "clang++")
+set(CMAKE_CXX_COMPILER "g++")
 
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,5 @@ set(CMAKE_CXX_COMPILER "clang++")
 enable_testing()
 
 add_subdirectory(src)
+add_subdirectory(utils)
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 project(ddg_bloom_cpp)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/make_filter.sh
+++ b/make_filter.sh
@@ -1,4 +1,4 @@
 directory=`dirname $0`
 mkdir $directory/build;
 (cd $directory/build; cmake ..; make all;)
-$directory/build/test/RunTests
+$directory/build/utils/GenerateFilter $1 $2 $3

--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -5,7 +5,7 @@
 
 // Forward declarations
 
-static unsigned int calculateHashRounds(unsigned int size, unsigned int maxItems);
+static size_t calculateHashRounds(size_t size, size_t maxItems);
 
 static unsigned int djb2Hash(string text);
 
@@ -29,24 +29,24 @@ static void unpackIntoVector(vector<bool> &bloomVector,
 
 // Implementation
 
-BloomFilter::BloomFilter(unsigned int maxItems, double targetProbability) {
-    unsigned int size = ceil((maxItems * log(targetProbability)) / log(1.0 / (pow(2.0, log(2.0)))));
+BloomFilter::BloomFilter(size_t maxItems, double targetProbability) {
+    auto size = (size_t) ceil((maxItems * log(targetProbability)) / log(1.0 / (pow(2.0, log(2.0)))));
     bloomVector = vector<bool>(size);
     hashRounds = calculateHashRounds(size, maxItems);
 }
 
-BloomFilter::BloomFilter(string importFilePath, unsigned int maxItems) {
+BloomFilter::BloomFilter(string importFilePath, size_t maxItems) {
     bloomVector = readVectorFromFile(importFilePath);
-    hashRounds = calculateHashRounds((unsigned int) bloomVector.size(), maxItems);
+    hashRounds = calculateHashRounds(bloomVector.size(), maxItems);
 }
 
-BloomFilter::BloomFilter(BinaryInputStream &in, unsigned int maxItems) {
+BloomFilter::BloomFilter(BinaryInputStream &in, size_t maxItems) {
     bloomVector = readVectorFromStream(in);
-    hashRounds = calculateHashRounds((unsigned int) bloomVector.size(), maxItems);
+    hashRounds = calculateHashRounds(bloomVector.size(), maxItems);
 }
 
-static unsigned int calculateHashRounds(unsigned int size, unsigned int maxItems) {
-    return round(log(2.0) * size / maxItems);
+static size_t calculateHashRounds(size_t size, size_t maxItems) {
+    return (size_t) round(log(2.0) * size / maxItems);
 }
 
 void BloomFilter::add(string element) {
@@ -55,7 +55,7 @@ void BloomFilter::add(string element) {
 
     for (int i = 0; i < hashRounds; i++) {
         unsigned int hash = doubleHash(hash1, hash2, i);
-        unsigned int index = hash % bloomVector.size();
+        size_t index = hash % bloomVector.size();
         bloomVector[index] = true;
     }
 }
@@ -66,7 +66,7 @@ bool BloomFilter::contains(string element) {
 
     for (int i = 0; i < hashRounds; i++) {
         unsigned int hash = doubleHash(hash1, hash2, i);
-        unsigned int index = hash % bloomVector.size();
+        size_t index = hash % bloomVector.size();
         if (!bloomVector[index]) {
             return false;
         }

--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <fstream>
 #include <cmath>
+#include <assert.h>
 #include "BloomFilter.hpp"
 
 // Forward declarations

--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cstdio>
 #include <fstream>
 #include <cmath>

--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
-#include <math.h>
+#include <cmath>
 #include "BloomFilter.hpp"
 
 // Forward declarations
@@ -15,15 +15,15 @@ static unsigned int doubleHash(unsigned int hash1, unsigned int hash2, unsigned 
 
 static void writeVectorToStream(vector<bool> &bloomVector, BinaryOutputStream &out);
 
-static BlockType pack(const vector<bool> &filter, const size_t block, const size_t bits);
+static BlockType pack(const vector<bool> &filter, size_t block, size_t bits);
 
 static vector<bool> readVectorFromFile(const string &path);
 
 static vector<bool> readVectorFromStream(BinaryInputStream &in);
 
 static void unpackIntoVector(vector<bool> &bloomVector,
-                             const size_t offset,
-                             const size_t bitsInThisBlock,
+                             size_t offset,
+                             size_t bitsInThisBlock,
                              BinaryInputStream &in);
 
 
@@ -133,7 +133,7 @@ static void writeVectorToStream(vector<bool> &bloomVector, BinaryOutputStream &o
     }
 }
 
-static BlockType pack(const vector<bool> &filter, const size_t block, const size_t bits) {
+static BlockType pack(const vector<bool> &filter, size_t block, size_t bits) {
 
     const size_t sizeOfTInBits = sizeof(BlockType) * 8;
     assert(bits <= sizeOfTInBits);
@@ -177,8 +177,8 @@ static vector<bool> readVectorFromStream(BinaryInputStream &in) {
 }
 
 static void unpackIntoVector(vector<bool> &bloomVector,
-                             const size_t offset,
-                             const size_t bitsInThisBlock,
+                             size_t offset,
+                             size_t bitsInThisBlock,
                              BinaryInputStream &in) {
 
     const BlockType block = in.get();

--- a/src/BloomFilter.hpp
+++ b/src/BloomFilter.hpp
@@ -16,11 +16,11 @@ typedef basic_ostream<BlockType> BinaryOutputStream;
 class BloomFilter {
 
 public:
-    BloomFilter(unsigned int maxItems, double targetProbability);
+    BloomFilter(size_t maxItems, double targetProbability);
 
-    BloomFilter(string importFilePath, unsigned int maxItems);
+    BloomFilter(string importFilePath, size_t maxItems);
 
-    BloomFilter(BinaryInputStream &in, unsigned int maxItems);
+    BloomFilter(BinaryInputStream &in, size_t maxItems);
 
     void add(string element);
 
@@ -31,6 +31,6 @@ public:
     void writeToStream(BinaryOutputStream &out);
 
 private:
-    unsigned int hashRounds;
+    size_t hashRounds;
     vector<bool> bloomVector;
 };

--- a/src/BloomFilter.hpp
+++ b/src/BloomFilter.hpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(BloomFilter BloomFilter.hpp BloomFilter.cpp)
 target_include_directories(BloomFilter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -27,8 +27,8 @@ using namespace std;
 
 static const unsigned int FILTER_ELEMENT_COUNT = 1000;
 static const unsigned int ADDITIONAL_TEST_DATA_ELEMENT_COUNT = 9000;
-static const double TARGET_FALSE_POSITIVE_RATE = 0.001;
-static const double ACCEPTABLE_FALSE_POSITIVE_RATE = TARGET_FALSE_POSITIVE_RATE * 1.1;
+static const double TARGET_ERROR_RATE = 0.001;
+static const double ACCEPTABLE_ERROR_RATE = TARGET_ERROR_RATE * 1.1;
 
 static string createRandomString() {
     uuid_t id;
@@ -53,21 +53,21 @@ static bool contains(set<string> set, const string &element) {
 }
 
 TEST_CASE("when BloomFilter is empty then contains is false") {
-    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_FALSE_POSITIVE_RATE);
+    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE);
     REQUIRE_FALSE(testee.contains("abc"));
 }
 
 TEST_CASE("when BloomFilter contains element then contains is true") {
-    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_FALSE_POSITIVE_RATE);
+    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE);
     testee.add("abc");
     REQUIRE(testee.contains("abc"));
 }
 
-TEST_CASE("when BloomFilter contains items then lookup results are within range") {
+TEST_CASE("when BloomFilter contains items then error is within range") {
 
     unsigned int falsePositives = 0, truePositives = 0, falseNegatives = 0, trueNegatives = 0;
 
-    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_FALSE_POSITIVE_RATE);
+    BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_ERROR_RATE);
     set<string> bloomData = createRandomStrings(FILTER_ELEMENT_COUNT);
     set<string> testData = createRandomStrings(ADDITIONAL_TEST_DATA_ELEMENT_COUNT);
     testData.insert(bloomData.begin(), bloomData.end());
@@ -84,9 +84,9 @@ TEST_CASE("when BloomFilter contains items then lookup results are within range"
         if (contains(bloomData, element) && result) truePositives++;
     }
 
-    double falsePositiveRate = falsePositives / testData.size();
+    double errorRate = (falsePositives + falseNegatives) / testData.size();
     REQUIRE(falseNegatives == 0);
     REQUIRE(truePositives == bloomData.size());
     REQUIRE(trueNegatives <= (testData.size() - bloomData.size()));
-    REQUIRE(falsePositiveRate <= ACCEPTABLE_FALSE_POSITIVE_RATE);
+    REQUIRE(errorRate <= ACCEPTABLE_ERROR_RATE);
 }

--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -34,10 +34,10 @@ static string createRandomString() {
     uuid_t id;
     uuid_generate(id);
 
-    uuid_string_t stringId;
+    char* stringId;
     uuid_unparse(id, stringId);
 
-    return (char *) stringId;
+    return stringId;
 }
 
 static set<string> createRandomStrings(unsigned int count) {

--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <vector>
 #include <uuid/uuid.h>
 #include "BloomFilter.hpp"
 
@@ -25,16 +24,16 @@ static string createRandomString() {
     return (char *) stringId;
 }
 
-static vector<string> createRandomStrings(unsigned int count) {
-    vector<string> vector(count);
+static set<string> createRandomStrings(unsigned int count) {
+    set<string> set;
     for (int i = 0; i < count; i++) {
-        vector[i] = createRandomString();
+        set.insert(createRandomString());
     }
-    return vector;
+    return set;
 }
 
-static bool contains(vector<string> vector, string element) {
-    return find(vector.begin(), vector.end(), element) != vector.end();
+static bool contains(set<string> set, const string &element) {
+    return set.find(element) != set.end();
 }
 
 TEST_CASE("when BloomFilter is empty then contains is false") {
@@ -53,20 +52,20 @@ TEST_CASE("when BloomFilter contains items then lookup results are within range"
     unsigned int falsePositives = 0, truePositives = 0, falseNegatives = 0, trueNegatives = 0;
 
     BloomFilter testee(FILTER_ELEMENT_COUNT, TARGET_FALSE_POSITIVE_RATE);
-    vector<string> bloomData = createRandomStrings(FILTER_ELEMENT_COUNT);
-    vector<string> testData = createRandomStrings(ADDITIONAL_TEST_DATA_ELEMENT_COUNT);
-    testData.insert(end(testData), begin(bloomData), end(bloomData));
+    set<string> bloomData = createRandomStrings(FILTER_ELEMENT_COUNT);
+    set<string> testData = createRandomStrings(ADDITIONAL_TEST_DATA_ELEMENT_COUNT);
+    testData.insert(bloomData.begin(), bloomData.end());
 
     for (const auto &i : bloomData) {
         testee.add(i);
     }
 
-    for (int i = 0; i < testData.size(); i++) {
-        bool result = testee.contains(testData[i]);
-        if (contains(bloomData, testData[i]) && !result) falseNegatives++;
-        if (!contains(bloomData, testData[i]) && result) falsePositives++;
-        if (!contains(bloomData, testData[i]) && !result) trueNegatives++;
-        if (contains(bloomData, testData[i]) && result) truePositives++;
+    for (const auto &element : testData) {
+        bool result = testee.contains(element);
+        if (contains(bloomData, element) && !result) falseNegatives++;
+        if (!contains(bloomData, element) && result) falsePositives++;
+        if (!contains(bloomData, element) && !result) trueNegatives++;
+        if (contains(bloomData, element) && result) truePositives++;
     }
 
     double falsePositiveRate = falsePositives / testData.size();

--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <iostream>
 #include <uuid/uuid.h>
 #include "BloomFilter.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_library(Catch ../third-party/catch2/single_include/catch2/catch.hpp empty.cpp)
 target_include_directories(Catch PUBLIC ../third-party/catch2/single_include/catch2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 
+if(UNIX AND NOT APPLE)
+    link_libraries(uuid)
+endif()
+
 add_library(Catch ../third-party/catch2/single_include/catch2/catch.hpp empty.cpp)
 target_include_directories(Catch PUBLIC ../third-party/catch2/single_include/catch2)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.5)
 
 if(APPLE)
     include_directories(/usr/local/opt/openssl/include)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.12)
+
+if(APPLE)
+    include_directories(/usr/local/opt/openssl/include)
+    link_directories(/usr/local/opt/openssl/lib)
+    link_libraries(crypto)
+endif()
+
+add_executable (GenerateFilter GenerateFilter.cpp)
+
+if(APPLE)
+    target_link_libraries (GenerateFilter LINK_PUBLIC BloomFilter crypto)
+else()
+    target_link_libraries (GenerateFilter LINK_PUBLIC BloomFilter)
+endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.5)
 if(APPLE)
     include_directories(/usr/local/opt/openssl/include)
     link_directories(/usr/local/opt/openssl/lib)
-    link_libraries(crypto)
 endif()
 
+link_libraries(crypto)
 add_executable (GenerateFilter GenerateFilter.cpp)
 
 if(APPLE)

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -52,7 +52,7 @@ int main(int argc, char *argv[], char *envp[]) {
     string bloomOutputFile = string(argv[3]) + "-bloom.bin";
     string bloomSpecOutputFile = string(argv[3]) + "-bloom-spec.json";
     string whitelistOutputFile = string(argv[3]) + "-whitelist.json";
-    double errorRate = 0.00001;
+    double errorRate = 0.000001;
 
     cout << "Generating filter" << endl;
     set<string> bloomInput = readStringsFromFile(bloomDataFile);

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -91,11 +91,7 @@ int main(int argc, char *argv[], char *envp[]) {
     writeWhitelistToFile(whitelistData, whitelistOutputFile);
 
     double actualErrorRate = whitelistData.size() / (double) validationData.size();
-    cout << "Actual error rate is " << actualErrorRate << endl;
-    if (actualErrorRate > errorRate * 1.1) {
-        cerr << "Error rate is too high" << endl;
-        return 1;
-    }
+    cout << "Actual error rate was " << actualErrorRate << endl;
 
     cout << "Generating filter specification" << endl;
     string sha256 = generateSha256(bloomOutputFile);

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -1,0 +1,135 @@
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <set>
+#include <openssl/sha.h>
+
+#include "BloomFilter.hpp"
+
+using namespace std;
+
+
+// Forward declarations
+
+static set<string> readStringsFromFile(const string &fileName);
+
+static void writeWhitelistToFile(const vector<string> &whitelistData, const string &fileName);
+
+static string generateSha256(const string &fileName);
+
+static string generateSpecification(size_t entries, double errorRate, const string &sha256);
+
+static void replace(string &string, const std::string &fromString, const std::string &toString);
+
+
+// Bloom generation script
+
+int main(int argc, char *argv[], char *envp[]) {
+
+    if (argc != 4) {
+        cerr << "Usage: INPUT_FILE VALIDATION_FILE OUTPUT_FILES_PREFIX" << endl;
+        return 1;
+    }
+
+    string bloomDataFile = argv[1];
+    string validationDataFile = argv[2];
+    string bloomOutputFile = string(argv[3]) + "-bloom.bin";
+    string bloomSpecOutputFile = string(argv[3]) + "-bloom-spec.json";
+    string whitelistOutputFile = string(argv[3]) + "-whitelist.json";
+    double errorRate = 0.0001;
+
+    cout << "Generating filter" << endl;
+    set<string> bloomInput = readStringsFromFile(bloomDataFile);
+    BloomFilter filter((int) bloomInput.size(), errorRate);
+    for (const string &entry : bloomInput) {
+        if (!entry.empty()) {
+            filter.add(entry);
+        }
+    }
+    filter.writeToFile(bloomOutputFile);
+
+    cout << "Generating whitelist" << endl;
+    set<string> validationData = readStringsFromFile(validationDataFile);
+    vector<string> whitelistData;
+    for (const string &entry : validationData) {
+        bool isInFilter = bloomInput.find(entry) != bloomInput.end();
+        if (filter.contains(entry) && !isInFilter) {
+            whitelistData.push_back(entry);
+        }
+    }
+    writeWhitelistToFile(whitelistData, whitelistOutputFile);
+
+    cout << "Generating filter specification" << endl;
+    string sha256 = generateSha256(bloomOutputFile);
+    string spec = generateSpecification(bloomInput.size(), errorRate, sha256);
+    ofstream specOutput(bloomSpecOutputFile);
+    specOutput << spec;
+}
+
+static set<string> readStringsFromFile(const string &fileName) {
+
+    set<string> data;
+
+    string line;
+    ifstream file(fileName);
+    while (getline(file, line)) {
+        data.insert(line);
+    }
+
+    return data;
+}
+
+static void writeWhitelistToFile(const vector<string> &whitelistData, const string &fileName) {
+    ofstream file(fileName);
+    file << "{ \"data\": [" << endl;
+
+    for (int i = 0; i < whitelistData.size(); i++) {
+        file << "\"" << whitelistData[i] << "\"";
+        if (i < whitelistData.size() - 1) {
+            file << ",";
+        }
+        file << endl;
+    }
+
+    file << "]}";
+}
+
+static string generateSha256(const string &fileName) {
+
+    ifstream file(fileName);
+    string fileContents((istreambuf_iterator<char>(file)), istreambuf_iterator<char>());
+
+    unsigned char hash[SHA256_DIGEST_LENGTH];
+    SHA256_CTX sha256;
+    SHA256_Init(&sha256);
+    SHA256_Update(&sha256, fileContents.c_str(), fileContents.size());
+    SHA256_Final(hash, &sha256);
+
+    stringstream ss;
+    for (auto element : hash) {
+        ss << hex << setw(2) << setfill('0') << (int) element;
+    }
+
+    return ss.str();
+}
+
+static string generateSpecification(size_t entries, double errorRate, const string &sha256) {
+
+    string specification = R"({
+        "totalEntries" : ENTRIES,
+        "errorRate"    : ERROR,
+        "sha256"       : "SHA256"
+    })";
+
+    replace(specification, "ENTRIES", to_string(entries));
+    replace(specification, "ERROR", to_string(errorRate));
+    replace(specification, "SHA256", sha256);
+
+    return specification;
+}
+
+static void replace(string &string, const std::string &fromString, const std::string &toString) {
+    size_t fromIndex = string.find(fromString);
+    size_t toIndex = fromString.length();
+    string.replace(fromIndex, toIndex, toString);
+}

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -90,10 +90,10 @@ int main(int argc, char *argv[], char *envp[]) {
     }
     writeWhitelistToFile(whitelistData, whitelistOutputFile);
 
-    double falsePositiveRate = whitelistData.size() / (double) validationData.size();
-    cout << "Actual false positive rate was " << falsePositiveRate << endl;
-    if (falsePositiveRate > errorRate * 1.1) {
-        cerr << "Error false positive rate is too high" << endl;
+    double actualErrorRate = whitelistData.size() / (double) validationData.size();
+    cout << "Actual error rate is " << actualErrorRate << endl;
+    if (actualErrorRate > errorRate * 1.1) {
+        cerr << "Error rate is too high" << endl;
         return 1;
     }
 

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <fstream>
 #include <iomanip>
 #include <sstream>

--- a/utils/GenerateFilter.cpp
+++ b/utils/GenerateFilter.cpp
@@ -56,10 +56,11 @@ int main(int argc, char *argv[], char *envp[]) {
 
     cout << "Generating filter" << endl;
     set<string> bloomInput = readStringsFromFile(bloomDataFile);
-    if (bloomInput.size() == 0) {
+    if (bloomInput.empty()) {
         cerr << "Error there was no data in " << bloomDataFile << endl;
         return 1;
     }
+
     BloomFilter filter(bloomInput.size(), errorRate);
     for (const string &entry : bloomInput) {
         filter.add(entry);
@@ -71,10 +72,11 @@ int main(int argc, char *argv[], char *envp[]) {
 
     cout << "Validating data and generating whitelist" << endl;
     set<string> validationData = readStringsFromFile(validationDataFile);
-    if (validationData.size() == 0) {
+    if (validationData.empty()) {
         cerr << "Error there was no data in " << validationDataFile << endl;
         return 1;
     }
+
     vector<string> whitelistData;
     for (const string &entry : validationData) {
         bool isInFilter = bloomInput.find(entry) != bloomInput.end();


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/758705520463116

**Description**:
- Add a script to create a binary bloom filter and an associated whitelist for false positives
- Update CMakeList.txt files to work on our linux servers as well as ubuntu
- Switch Catch testing submodule to point to ddg fork
- Tidy up, switch `unsigned int` types to `size_t` where appropriate and remove unneeded `const`

**Steps to test this PR**:

**Testing: option one - Dev instance:**
- Log onto dev instance ddh3
- Go to https folder: `cd /usr/local/ddg/components/https`
- Run ./update-mobile-bloom-filter.bash
- Check that no errors are thrown and output files (https-mobile-bloom.bin, https-mobile-bloom-spec.json and https-mobile-whitelist.json are generated)

**Testing: option two - Local mac:**
- request data files from mia, to be shared over Resilio sync
- run the `make_filter` script
- `./make_filter.sh mobile_upgrades.txt mobile_static_domains.txt https-mobile`
- Check that no errors are thrown and output files (https-mobile-bloom.bin, https-mobile-bloom-spec.json and https-mobile-whitelist.json are generated)

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)