### PR TITLE
Balance test data and ensure error range test fails when threshold breached

### DIFF
--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -25,10 +25,10 @@
 
 using namespace std;
 
-static const unsigned int FILTER_ELEMENT_COUNT = 1000;
-static const unsigned int ADDITIONAL_TEST_DATA_ELEMENT_COUNT = 9000;
+static const unsigned int FILTER_ELEMENT_COUNT = 5000;
+static const unsigned int ADDITIONAL_TEST_DATA_ELEMENT_COUNT = 5000;
 static const double TARGET_ERROR_RATE = 0.001;
-static const double ACCEPTABLE_ERROR_RATE = TARGET_ERROR_RATE * 1.1;
+static const double ACCEPTABLE_ERROR_RATE = TARGET_ERROR_RATE * 2;
 
 static string createRandomString() {
     uuid_t id;
@@ -84,7 +84,7 @@ TEST_CASE("when BloomFilter contains items then error is within range") {
         if (contains(bloomData, element) && result) truePositives++;
     }
 
-    double errorRate = (falsePositives + falseNegatives) / testData.size();
+    double errorRate = (falsePositives + falseNegatives) / (double) testData.size();
     REQUIRE(falseNegatives == 0);
     REQUIRE(truePositives == bloomData.size());
     REQUIRE(trueNegatives <= (testData.size() - bloomData.size()));


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/903182762228930/903182762228932

**Description**:
Balance positive / negative test data and fix integer division that makes one test always pass. 

**Steps to test this PR**:
1. Run ./run_tests and ensure they all pass
1. In BloomFilterTest.cpp, update TARGET_ERROR_RATE to 0.5 and run the tests again and ensure they fail this time

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)