### PR TITLE
Update to latest version of catch test library and cleanup config

### DIFF
--- a/test/BloomFilterTest.cpp
+++ b/test/BloomFilterTest.cpp
@@ -18,9 +18,7 @@
 #include <uuid/uuid.h>
 #include "BloomFilter.hpp"
 
-#define CATCH_CONFIG_MAIN
-
-#include "catch.hpp"
+#include "Test.hpp"
 
 
 using namespace std;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,11 +4,7 @@ if(UNIX AND NOT APPLE)
     link_libraries(uuid)
 endif()
 
-add_library(Catch ../third-party/catch2/single_include/catch2/catch.hpp empty.cpp)
-target_include_directories(Catch PUBLIC ../third-party/catch2/single_include/catch2)
-
 add_executable (RunTests BloomFilterTest.cpp)
-target_link_libraries (RunTests LINK_PUBLIC Catch)
 target_link_libraries (RunTests LINK_PUBLIC BloomFilter)
 
 add_test(NAME RunTests COMMAND RunTests)

--- a/test/Test.hpp
+++ b/test/Test.hpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define CATCH_CONFIG_MAIN
+
+#include "../third-party/catch2/single_include/catch2/catch.hpp"

--- a/test/empty.cpp
+++ b/test/empty.cpp
@@ -1,1 +1,0 @@
-// Required by cmake to identify language for catch.


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

Task/Issue URL: https://app.asana.com/0/903182762228930/1196172063855401

**Description**:
Our Catch unit test library is out-of-date and our config is a little complicated, creating a library dependency when we could just import the header. This PR switches to the latest version of the lib and simplifies config.

**Steps to test this PR**:
1. Checkout the project
1. Run `git submodule update --init --recursive` to bring in the submodule (your source control tools may have already done this)
1. Run tests `./run_test.sh`

---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
