### PR TITLE
The "char" type might be signed, both hash functions are defined to w…

### DIFF
--- a/src/BloomFilter.cpp
+++ b/src/BloomFilter.cpp
@@ -105,16 +105,16 @@ bool BloomFilter::contains(const string &element) {
 
 static unsigned int djb2Hash(const string &text) {
     unsigned int hash = 5381;
-    for (const char &iterator : text) {
-        hash = ((hash << 5) + hash) + iterator;
+    for (auto ch : text) {
+        hash = ((hash << 5) + hash) + static_cast<unsigned char>(ch);
     }
     return hash;
 }
 
 static unsigned int sdbmHash(const string &text) {
     unsigned int hash = 0;
-    for (const char &iterator : text) {
-        hash = iterator + ((hash << 6) + (hash << 16) - hash);
+    for (auto ch : text) {
+        hash = static_cast<unsigned char>(ch) + ((hash << 6) + (hash << 16) - hash);
     }
     return hash;
 }


### PR DESCRIPTION
…ork on unsigned 8-bit values.

<!--
Note: This checklist is a reminder of our shared engineering expectations. Feel free to change it, although assigning a GitHub reviewer and the items in bold are required.
-->

**Description**:

For example, DJB's C code for this hash function is:

uint32 cdb_hash(buf,len)
unsigned char *buf;
unsigned int len;
{
  uint32 h;

  h = 5381;
  while (len) {
    --len;
    h += (h << 5);
    h ^= (uint32) *buf++;
  }
  return h;
}

This code uses + in place of ^, but that I think is a choice and not just an oversight.

**Steps to test this PR**:
1. 
1. 


---
###### Internal references:
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552)
[Technical Design Template](https://app.asana.com/0/59792373528535/184709971311943)
